### PR TITLE
Add in macOS + Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,35 @@ NonEuclidean/.vs/NonEuclidean/v17/.suo
 *.db
 *.vcxproj
 *.filters
+
+# CMake build files
+build/
+cmake-build-*/
+out/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+# Compiled binaries
+NonEuclidean
+NonEuclidean.exe
+*.exe
+*.out
+*.app
+
+# macOS
+.DS_Store
+*.dSYM/
+
+# Linux
+*.so
+*.a
+
+# IDEs
+.idea/
+*.swp
+*.swo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.16)
+project(NonEuclidean VERSION 1.1 LANGUAGES CXX)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find SFML
+find_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)
+
+# Source files
+set(SOURCES
+    NonEuclidean/main.cpp
+    NonEuclidean/player.cpp
+    NonEuclidean/render.cpp
+    NonEuclidean/node.cpp
+    NonEuclidean/texture.cpp
+    NonEuclidean/textures.cpp
+)
+
+# Header files
+set(HEADERS
+    NonEuclidean/main.hpp
+    NonEuclidean/player.hpp
+    NonEuclidean/render.hpp
+    NonEuclidean/node.hpp
+    NonEuclidean/texture.hpp
+    NonEuclidean/textures.hpp
+)
+
+# Create executable
+add_executable(NonEuclidean ${SOURCES} ${HEADERS})
+
+# Link SFML libraries
+target_link_libraries(NonEuclidean PRIVATE sfml-graphics sfml-window sfml-system)
+
+# Copy font file to build directory
+configure_file(${CMAKE_SOURCE_DIR}/NonEuclidean/ubuntu.ttf ${CMAKE_BINARY_DIR}/ubuntu.ttf COPYONLY)
+
+# Set output directory
+set_target_properties(NonEuclidean PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+# Platform-specific settings
+if(APPLE)
+    # macOS specific settings
+    set_target_properties(NonEuclidean PROPERTIES
+        MACOSX_BUNDLE FALSE
+    )
+elseif(UNIX AND NOT APPLE)
+    # Linux specific settings
+    target_link_libraries(NonEuclidean PRIVATE pthread)
+endif()
+
+# Enable warnings
+if(MSVC)
+    target_compile_options(NonEuclidean PRIVATE /W4)
+else()
+    target_compile_options(NonEuclidean PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+# Print build info
+message(STATUS "Building NonEuclidean v${PROJECT_VERSION}")
+message(STATUS "C++ Standard: ${CMAKE_CXX_STANDARD}")
+message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")

--- a/README.md
+++ b/README.md
@@ -5,13 +5,73 @@ NonEuclidean is a 3D game engine that simulates non-euclidean geometries. Player
 
 ## Technologies
 This project was built with:
-* C++ programming language
-* SFML library for graphics and input handling
+* C++ (C++17 or later)
+* SFML 2.5+ library for graphics and input handling
+* CMake 3.16+ for cross-platform builds
 
 ## Setup
-1. Install SFML by following the instructions on the official SFML website.
-2. Clone this repository onto your local machine.
-3. Build and run the project using your favorite IDE or command line tools.
+
+### Prerequisites
+Install SFML 2.5 or later:
+
+**macOS** (using Homebrew):
+```bash
+brew install sfml
+```
+
+**Ubuntu/Debian**:
+```bash
+sudo apt-get update
+sudo apt-get install libsfml-dev
+```
+
+**Arch Linux**:
+```bash
+sudo pacman -S sfml
+```
+
+**Windows**:
+- Download SFML from the [official website](https://www.sfml-dev.org/download.php)
+- Or use Visual Studio with the included project files
+
+### Building with CMake (macOS/Linux/Windows)
+
+**Quick Build (macOS/Linux)**:
+```bash
+./build.sh
+./build/NonEuclidean
+```
+
+**Manual Build**:
+
+1. Clone this repository:
+```bash
+git clone https://github.com/yourusername/NonEuclidean.git
+cd NonEuclidean
+```
+
+2. Create a build directory:
+```bash
+mkdir build
+cd build
+```
+
+3. Generate build files and compile:
+```bash
+cmake ..
+cmake --build .
+```
+
+4. Run the game:
+```bash
+./NonEuclidean
+```
+
+### Building with Visual Studio (Windows)
+
+1. Clone this repository
+2. Open `NonEuclidean/NonEuclidean.sln` in Visual Studio
+3. Build and run the project (F5)
 
 If you encounter any issues during setup, please refer to the Troubleshooting section below.
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Build script for NonEuclidean (macOS/Linux)
+
+echo "Building NonEuclidean..."
+
+# Create build directory if it doesn't exist
+if [ ! -d "build" ]; then
+    echo "Creating build directory..."
+    mkdir build
+fi
+
+# Navigate to build directory
+cd build
+
+# Run CMake
+echo "Running CMake..."
+cmake ..
+
+# Build the project
+echo "Compiling..."
+cmake --build .
+
+# Check if build was successful
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "Build successful!"
+    echo "Run the game with: ./build/NonEuclidean"
+else
+    echo ""
+    echo "Build failed. Please check the error messages above."
+    exit 1
+fi


### PR DESCRIPTION
- Add CMakeLists.txt for CMake-based builds across all platforms
- Add build.sh convenience script for macOS/Linux quick builds
- Update .gitignore with CMake and platform-specific entries
- Update README.md with comprehensive build instructions for:
  - macOS (using Homebrew for SFML)
  - Linux (Ubuntu, Debian, Arch)
  - Windows (CMake and Visual Studio)
- Code verified to be platform-agnostic (no Windows-specific APIs)

The project now supports building on macOS, Linux, and Windows while maintaining backward compatibility with Visual Studio.

thanks clod :)