### PR TITLE
Add 6 mind-bending non-euclidean levels with level selection system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,9 +415,8 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 
-# Compiled binaries
-NonEuclidean
-NonEuclidean.exe
+# Compiled binaries (in build directory only)
+/build/NonEuclidean
 *.exe
 *.out
 *.app

--- a/NonEuclidean/main.hpp
+++ b/NonEuclidean/main.hpp
@@ -19,7 +19,8 @@ const int MAP_HEIGHT = 16;
 const double MOUSE_SENSITIVITY = 0.0005;
 const double PLAYER_MOVE_DISTANCE = 0.05;
 
-const std::vector<std::string> level = {
+// Level 1: Portal Basics - Introduction to non-euclidean portals
+const std::vector<std::string> level1 = {
 	"..............x...............",
 	"..............x...............",
 	"..............x.BBBBBBBBBBBBB.",
@@ -36,4 +37,104 @@ const std::vector<std::string> level = {
 	"...GGGGGGG....x...............",
 	"..............x...............",
 	"..............x..............."
+};
+
+// Level 2: The Impossible Loop - Walk in a square and end up elsewhere
+const std::vector<std::string> level2 = {
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR",
+	"R............................R",
+	"R.BBBBBBBBBBBB..YYYYYYYYYYYY.R",
+	"R.B..........B..Y..........Y.R",
+	"R.B..........B..Y..........Y.R",
+	"R.B..........B..Y..........Y.R",
+	"R.B..........B..Y..........Y.R",
+	"R.B..........B..Y..........Y.R",
+	"R.B..........BBBY..........Y.R",
+	"R.B.......................GY.R",
+	"R.B.GGGGGGGGGGGGGGGGGGGGGGGY.R",
+	"R.B.G......................Y.R",
+	"R.BBB......................Y.R",
+	"R..........................Y.R",
+	"R.YYYYYYYYYYYYYYYYYYYYYYYYYY.R",
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR"
+};
+
+// Level 3: Bigger on the Inside - TARDIS effect
+const std::vector<std::string> level3 = {
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR",
+	"R............................R",
+	"R............................R",
+	"R............................R",
+	"R..........BBBB..............R",
+	"R..........B..B..............R",
+	"R..........B..B..............R",
+	"R..........BBBB..............R",
+	"R............................R",
+	"R............................R",
+	"RGGGGGGGGGGGGGGGGGGGGGGGGGGGGR",
+	"RG..........................GR",
+	"RG..YYYYYYYYYYYYYYYYYYYYYY..GR",
+	"RG..Y....................Y..GR",
+	"RG..YYYYYYYYYYYYYYYYYYYYYY..GR",
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR"
+};
+
+// Level 4: The Mirror Maze - Left and right are the same space
+const std::vector<std::string> level4 = {
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR",
+	"R............BB............BBR",
+	"R...........B..B..........B..R",
+	"R..........B....B........B...R",
+	"R.........B......B......B....R",
+	"R........BYYYYYYYYYYYYYB.....R",
+	"R.......BY..............B....R",
+	"R.......Y................B...R",
+	"R.......Y.................B..R",
+	"R.......Y..................B.R",
+	"R.......Y..................B.R",
+	"R.......Y.................B..R",
+	"R.......BY...............B...R",
+	"R........BYYYYYYYYYYYYYB.....R",
+	"R.........BBBBBBBBBBBB.......R",
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR"
+};
+
+// Level 5: The Escher Staircase - Penrose stairs
+const std::vector<std::string> level5 = {
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR",
+	"R...........BBBBB............R",
+	"R...........B...B............R",
+	"R...GGGGGGGGG...BBBBBBBBB....R",
+	"R...G...................B....R",
+	"R...G...................B....R",
+	"YYYYG...................BYYYYY",
+	"R...G...................B....R",
+	"R...G...................B....R",
+	"R...GGGGGGGGGGGGGGGGGGGGG....R",
+	"R............................R",
+	"R............................R",
+	"R....BBBBBBBBBBBBBBBBBBBB....R",
+	"R....B..................B....R",
+	"R....BBBBBBBBBBBBBBBBBBBB....R",
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR"
+};
+
+// Level 6: Recursive Rooms - A room that contains itself
+const std::vector<std::string> level6 = {
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR",
+	"R..BBBB..........BBBB........R",
+	"R..B..B..........B..B........R",
+	"R..B..BGGGGGGGGGGG..BGGGGGGGGR",
+	"R..B..BG..........BBG........R",
+	"R..BBBGG..........BBB........R",
+	"R.....BG.....................R",
+	"R.....BG.....................R",
+	"R.....BG..YYY..YYY..YYY......R",
+	"R.....BG..Y.Y..Y.Y..Y.Y......R",
+	"R.....BG..YYY..YYY..YYY......R",
+	"R.....BG.....................R",
+	"R.....BGGGGGGGGGGGGGGGGGGGGGGR",
+	"R.....B......................R",
+	"R.....BBBBBBBBBBBBBBBBBBBBBBBR",
+	"RRRRRRRRRRRRRRRRRRRRRRRRRRRRRR"
 };


### PR DESCRIPTION
Implemented diverse non-euclidean geometry demonstrations:

Level 1: Portal Basics - Introduction to portals
- Vertical portal connecting red and blue rooms
- Horizontal wrap portal in green room

Level 2: The Impossible Loop - Walking in circles leads elsewhere
- Square corridor that teleports you when completing the loop
- Demonstrates space is not globally consistent

Level 3: Bigger on the Inside - TARDIS effect
- Small blue box exterior
- Massive green room interior (impossible space)
- Recursive yellow room is even bigger

Level 4: The Mirror Maze - Symmetric mirrored space
- Left and right sides are the SAME location
- Walking left teleports you to the right side
- Very disorienting mirror geometry

Level 5: The Escher Staircase - Penrose stairs concept
- Walk in a loop going "up" continuously
- End up back at the start (impossible vertical geometry)
- Classic MC Escher demonstration

Level 6: Recursive Rooms - A room that contains itself
- Multiple entrances to "different" rooms are the same room
- Room recursively contains copies of itself
- Mind-bending spatial recursion

Features:
- Press 1-6 to switch between levels instantly
- On-screen level name indicator
- Instructions display at bottom of screen
- Proper memory cleanup when switching levels
- Each level showcases different impossible geometry concepts
- Fixed .gitignore to not ignore source directory

Technical improvements:
- Refactored map loading with buildWorld() helper
- Created separate map functions for each level
- Level selection system with loadLevel()
- Added getLevelName() for UI display

holy crap claude can do this????